### PR TITLE
Fix routing for subdirectory deployments

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,63 @@
+# Use the front controller as index file. It serves as a fallback solution when
+# every other rewrite/redirect fails (e.g. in an aliased environment without
+# mod_rewrite). Additionally, this reduces the matching process for the
+# start page (path "/") because otherwise Apache will apply the rewriting rules
+# to each configured DirectoryIndex file (e.g. index.php, index.html, index.pl).
+DirectoryIndex index.php
+
+# By default, Apache does not evaluate symbolic links if you did not enable this
+# feature in your server configuration. Uncomment the following line if you
+# install assets as symbolic links or if you experience problems related to
+# symlinks when compiling LESS/Sass/CoffeScript assets.
+# Options +FollowSymlinks
+
+# Disabling MultiViews prevents unwanted negotiation, e.g. "/index" should not
+# resolve on the front controller "/index.php" but be rewritten to "/index.php/index".
+<IfModule mod_negotiation.c>
+    Options -MultiViews
+</IfModule>
+
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+
+    # Determine the RewriteBase automatically and set it as environment variable.
+    # If you are using Apache aliases to do mass virtual hosting or installed the
+    # project in a subdirectory, the base path will be prepended to allow proper
+    # resolution of the index.php file and to redirect to the correct URI. It will
+    # work in environments without path prefix as well, providing a safe, one-size
+    # fits all solution.
+    RewriteCond %{REQUEST_URI}::$0 ^(/.+)(.+)::\2$
+    RewriteRule ^(.*) - [E=BASE:%1]
+
+    # Sets the HTTP_AUTHORIZATION header removed by Apache
+    RewriteCond %{HTTP:Authorization} .+
+    RewriteRule ^ - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
+    # Redirect to URI without front controller to prevent duplicate content
+    # (with and without `/index.php`). Only do this redirect on the initial
+    # rewrite by Apache and not on subsequent cycles. Otherwise we would get an
+    # endless redirect loop (request -> rewrite to front controller ->
+    # redirect -> request -> ...).
+    # So in case you get a "too many redirects" error or you always get redirected
+    # to the start page because your Apache does not expose the REDIRECT_STATUS
+    # environment variable, you have 2 choices:
+    # - disable this feature by commenting the following 2 lines or
+    # - use Apache >= 2.3.9 and replace all L flags by END flags and remove the
+    #   following RewriteCond (best solution)
+    RewriteCond %{ENV:REDIRECT_STATUS} =""
+    RewriteRule ^index\.php(?:/(.*)|$) %{ENV:BASE}/$1 [R=301,L]
+
+    # If the requested filename exists, don't rewrite it.
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteRule ^ %{ENV:BASE}/index.php [L]
+</IfModule>
+
+<IfModule !mod_rewrite.c>
+    <IfModule mod_alias.c>
+        # When mod_rewrite is not available, we instruct a temporary redirect of
+        # the start page to the front controller explicitly so that the website
+        # and the generated links can still be used.
+        RedirectMatch 302 ^/$ /index.php/
+        # RedirectTemp cannot be used instead
+    </IfModule>
+</IfModule>

--- a/templates/transform/index.html.twig
+++ b/templates/transform/index.html.twig
@@ -28,7 +28,7 @@
 
     <!-- Upload Form -->
     <div id="upload-form" class="bg-white rounded-lg shadow-lg p-8 mb-8 fade-in">
-        <form id="file-upload-form" action="/transform" method="POST" enctype="multipart/form-data" class="space-y-6">
+        <form id="file-upload-form" action="{{ path('app_transform_upload') }}" method="POST" enctype="multipart/form-data" class="space-y-6">
             <input type="hidden" name="_token" value="{{ csrf_token }}">
             <!-- Drag and Drop Area -->
             <div id="upload-area" class="upload-area border-2 border-dashed border-gray-300 rounded-lg p-12 text-center cursor-pointer hover:border-blue-400 hover:bg-blue-50">
@@ -288,7 +288,7 @@ document.addEventListener('DOMContentLoaded', function() {
         formData.append('file', currentFile);
         formData.append('_token', '{{ csrf_token }}');
         
-        fetch('/transform', {
+        fetch('{{ path('app_transform_upload') }}', {
             method: 'POST',
             body: formData
         })


### PR DESCRIPTION
- Replace hardcoded /transform paths with Symfony path() function
- Add .htaccess file for proper Apache URL rewriting
- Support both root and subdirectory deployments automatically
- Fix 404 errors when deployed at https://www.francescoface.it/ynab-transformer/

The application now works correctly in both deployment scenarios:
- Root deployment: https://yoursite.com/transform
- Subdirectory deployment: https://yoursite.com/ynab-transformer/transform