### PR TITLE
Accept xlsx uploads regardless of sniffed MIME type

### DIFF
--- a/src/Service/FileProcessingService.php
+++ b/src/Service/FileProcessingService.php
@@ -157,28 +157,10 @@ class FileProcessingService
             return false;
         }
 
-        // Check file type
         $allowedExtensions = ['xlsx', 'xls', 'csv'];
         $extension = strtolower($uploadedFile->getClientOriginalExtension());
-        
-        if (!in_array($extension, $allowedExtensions)) {
-            return false;
-        }
 
-        // Check MIME type
-        $allowedMimeTypes = [
-            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', // .xlsx
-            'application/vnd.ms-excel', // .xls
-            'text/csv', // .csv
-            'application/csv', // .csv
-            'text/plain', // .csv (common MIME type for CSV files)
-        ];
-        
-        if (!in_array($uploadedFile->getMimeType(), $allowedMimeTypes)) {
-            return false;
-        }
-
-        return true;
+        return in_array($extension, $allowedExtensions);
     }
 
     /**

--- a/tests/Service/FileProcessingServiceTest.php
+++ b/tests/Service/FileProcessingServiceTest.php
@@ -38,6 +38,15 @@ class FileProcessingServiceTest extends TestCase
         $this->assertTrue($result);
     }
 
+    public function test_validateUploadedFile_with_xlsx_detected_as_octet_stream_returns_true()
+    {
+        $file = $this->createMockUploadedFile('20260409_ListaOperazioni.xlsx', 'application/octet-stream', 11919);
+
+        $result = $this->service->validateUploadedFile($file);
+
+        $this->assertTrue($result);
+    }
+
     public function test_validateUploadedFile_with_invalid_file_type_returns_false()
     {
         $file = $this->createMockUploadedFile('document.pdf', 'application/pdf', 1024);


### PR DESCRIPTION
## Summary
- Some xlsx exports (observed with newer Isybank statements) are detected by libmagic as `application/octet-stream`, which the MIME whitelist in `FileProcessingService::validateUploadedFile` rejected — showing users a generic "Please upload a valid Excel..." error even though the file was valid.
- The CLI was unaffected because it never inspects MIME; it loads through `IOFactory::load` which sniffs content.
- Fix drops the MIME whitelist. Extension check + PhpSpreadsheet's own parsing remain as guardrails.

## Test plan
- [x] Added `test_validateUploadedFile_with_xlsx_detected_as_octet_stream_returns_true` regression test
- [x] Full suite green (126 tests)
- [x] Manually verified the original failing file now uploads via the web UI and returns a correct CSV

🤖 Generated with [Claude Code](https://claude.com/claude-code)