### PR TITLE
Ignore .claude/settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 /phpunit.xml
 .phpunit.result.cache
 ###< phpunit/phpunit ###
+
+# Per-user Claude Code permission overrides (keep local, don't share)
+/.claude/settings.local.json


### PR DESCRIPTION
Local per-user Claude Code permission grants — shouldn't be shared in VCS.